### PR TITLE
adapt toolchain uri change (404 error)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DL="https://github.com/OpenIPC/firmware/releases/download/toolchain/toolchain"
+DL="https://github.com/OpenIPC/firmware/releases/download/toolchain"
 
 if [ "$#" -ne 1 ]; then
 	echo "Usage: $0 [goke|hisi|star6b0|star6e|native]"
@@ -7,13 +7,13 @@ if [ "$#" -ne 1 ]; then
 fi
 
 if [[ "$1" == *"star6b0" ]]; then
-	CC=sigmastar-infinity6b0
+	CC=toolchain.sigmastar-infinity6b0
 elif [[ "$1" == *"star6e" ]]; then
-	CC=sigmastar-infinity6e
+	CC=toolchain.sigmastar-infinity6e
 elif [[ "$1" == *"goke" ]]; then
-	CC=goke-gk7205v200
+	CC=toolchain.goke-gk7205v200
 elif [[ "$1" == *"hisi" ]]; then
-	CC=hisilicon-hi3516ev200
+	CC=toolchain.hisilicon-hi3516ev200
 fi
 
 GCC=$PWD/toolchain/$CC/bin/arm-linux-gcc
@@ -21,9 +21,9 @@ OUT=msposd
 
 if [[ "$1" != *"native"* ]]; then
 	if [ ! -e toolchain/$CC ]; then
-		wget -c -q --show-progress $DL.$CC.tgz -P $PWD
+		wget -c -q --show-progress $DL/$CC.tgz -P $PWD
 		mkdir -p toolchain/$CC
-		tar -xf toolchain.$CC.tgz -C toolchain/$CC --strip-components=1 || exit 1
+		tar -xf $CC.tgz -C toolchain/$CC --strip-components=1 || exit 1
 		rm -f $CC.tgz
 	fi
 	OUT=msposd_$1


### PR DESCRIPTION
There are two issues:

1. toolchain addr is changed from `https://github.com/OpenIPC/firmware/releases/download/toolchain/toolchain` to `https://github.com/OpenIPC/firmware/releases/download/toolchain`
2. toolchain name is changed form `sigmastar-infinity6b0` to toolchain.sigmastar-infinity6b0`
