### PR TITLE
Add date setting to VTX menu

### DIFF
--- a/vtxmenu.ini
+++ b/vtxmenu.ini
@@ -16,6 +16,7 @@
 [VTX MENU]
 Submenu1=CAMERA SETTINGS
 Submenu2=WFB-NG SETTINGS
+Submenu3=DATE SETTINGS
 
 [CAMERA SETTINGS]
 Submenu1=IMAGE
@@ -88,4 +89,13 @@ Option10=FEC_N:1-20:grep fec_n /etc/wfb.conf | cut -d= -f2:sed -i 's/fec_n=.*/fe
 Option11=POOL_TIMEOUT:0,:grep pool_timeout /etc/wfb.conf | cut -d= -f2:sed -i 's/pool_timeout=.*/pool_timeout={}/' /etc/wfb.conf
 Option12=GUARD_INTERVAL:LONG,SHORT:grep guard_interval /etc/wfb.conf | cut -d= -f2 | tr a-z A-Z:sed -i "s/guard_interval=.*/guard_interval=$(echo {} | tr A-Z a-z)/" /etc/wfb.conf
 Option13=CHANNEL:36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136,140,144,149,153,157,161,165:grep ^channel /etc/wfb.conf | cut -d= -f2:sed -i 's/channel=.*/channel={}/' /etc/wfb.conf
+Submenu1=VTX MENU
+
+[DATE SETTINGS]
+Option1=Y:2025~2050:echo $(date +%Y):date -s "{}-$(date '+%m-%d %H:%M')"
+Option2=m:1-12:echo $(date +%m):date -s "$(date '+%Y')-{}-$(date '+%d %H:%M')"
+Option3=d:1-31:echo $(date +%d):date -s "$(date '+%Y-%m')-{} $(date '+%H:%M')"
+Option4=H:0-23:echo $(date +%H):date -s "$(date '+%Y-%m-%d') {}:$(date '+%M')"
+Option5=M:0-59:echo $(date +%M):date -s "$(date '+%Y-%m-%d %H'):{}"
+;Command1=File Date:date -s "@$(find /var/log -maxdepth 1 -type f -printf '%T@\n' | sort -n | tail -1)"‌
 Submenu1=VTX MENU

--- a/vtxmenu.ini
+++ b/vtxmenu.ini
@@ -92,10 +92,10 @@ Option13=CHANNEL:36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136
 Submenu1=VTX MENU
 
 [DATE SETTINGS]
-Option1=Y:2025~2050:echo $(date +%Y):date -s "{}-$(date '+%m-%d %H:%M')"
-Option2=m:1-12:echo $(date +%m):date -s "$(date '+%Y')-{}-$(date '+%d %H:%M')"
-Option3=d:1-31:echo $(date +%d):date -s "$(date '+%Y-%m')-{} $(date '+%H:%M')"
-Option4=H:0-23:echo $(date +%H):date -s "$(date '+%Y-%m-%d') {}:$(date '+%M')"
-Option5=M:0-59:echo $(date +%M):date -s "$(date '+%Y-%m-%d %H'):{}"
+Option1=YEAR  :2025-2050:echo $(date +%Y):date -s "{}-$(date '+%m-%d %H:%M')"
+Option2=MONTH :1-12:echo $(date +%m):date -s "$(date '+%Y')-{}-$(date '+%d %H:%M')"
+Option3=DAY   :1-31:echo $(date +%d):date -s "$(date '+%Y-%m')-{} $(date '+%H:%M')"
+Option4=HOUR  :0-23:echo $(date +%H):date -s "$(date '+%Y-%m-%d') {}:$(date '+%M')"
+Option5=MINUTE:0-59:echo $(date +%M):date -s "$(date '+%Y-%m-%d %H'):{}"
 ;Command1=File Date:date -s "@$(find /mnt/mmcblk0p1 -maxdepth 1 -type f -printf '%T@\n' | sort -n | tail -1)"‌
 Submenu1=VTX MENU

--- a/vtxmenu.ini
+++ b/vtxmenu.ini
@@ -97,5 +97,5 @@ Option2=m:1-12:echo $(date +%m):date -s "$(date '+%Y')-{}-$(date '+%d %H:%M')"
 Option3=d:1-31:echo $(date +%d):date -s "$(date '+%Y-%m')-{} $(date '+%H:%M')"
 Option4=H:0-23:echo $(date +%H):date -s "$(date '+%Y-%m-%d') {}:$(date '+%M')"
 Option5=M:0-59:echo $(date +%M):date -s "$(date '+%Y-%m-%d %H'):{}"
-;Command1=File Date:date -s "@$(find /var/log -maxdepth 1 -type f -printf '%T@\n' | sort -n | tail -1)"‌
+;Command1=File Date:date -s "@$(find /mnt/mmcblk0p1 -maxdepth 1 -type f -printf '%T@\n' | sort -n | tail -1)"‌
 Submenu1=VTX MENU


### PR DESCRIPTION
The root reason for modifying the time is that the sky-side card recording DVR stores files according to the system time. When offline, the system always use defaults time, resulting in chaotic connection of video files. Possible solutions include:
1. Modify the time
	1.1, Manually modify the time
	1.2, Automatically correct the time
		1.2.1, Use GPS data to synchronize the time
		1.2.2, The receiving end (Android) pushes the time
		1.2.3, Use the existing DVR to infer the time, at least avoid duplication
2, Modify the algorithm
	2.1, Detect the existence of the file and append a number
	2.2, Do not use time as the file name
This pr is method 1.1, method 1.2.3 is under test



修改时间的根本原因是天空端卡录DVR按系统时间存储文件，离线时系统总是默认时间，导致视频文件混乱连接在一起。可能的解決方式包括：
1,修改时间
	1.1,手动修改时间
	1.2,自动修正时间
		1.2.1，使用GPS数据同步时间
		1.2.2，接收端（安卓）推送时间
		1.2.3，借助已有DVR推测时间，至少避免重复
2,修改算法
	2.1，检测文件存在，追加数字
	2.2，不适用时间作为文件名
本pr为方法1.1,方法1.2.3测试中
