### PR TITLE
Fix UDP terminal handling and X11/libevent cleanup

### DIFF
--- a/msposd.c
+++ b/msposd.c
@@ -54,7 +54,7 @@ extern char* recording_dir;
 // libevent base main loop
 struct event_base *base = NULL;
 
-int serial_fd = 0;
+int serial_fd = -1;
 int in_sock = 0;
 int MSPUDPPort = 0;
 int MSP_PollRate = 20;
@@ -1217,6 +1217,10 @@ static int handle_data(const char *port_name, int baudrate, const char *out_addr
 		printf("Listening UART on %s...\n", port_name);
 	}
 
+	// In UDP mode there is no UART; do not apply raw termios settings to stdin.
+	if (serial_fd < 0)
+		goto uart_configured;
+
 	struct termios options;
 	tcgetattr(serial_fd, &options);
 	cfsetspeed(&options, speed_by_value(baudrate));
@@ -1253,6 +1257,8 @@ static int handle_data(const char *port_name, int baudrate, const char *out_addr
 		msp_set_vtx_config(serial_fd);
 	}
 
+uart_configured:
+
 	if (strlen(out_addr) > 1) {
 		out_sock = socket(AF_INET, SOCK_DGRAM, 0);
 
@@ -1280,7 +1286,7 @@ static int handle_data(const char *port_name, int baudrate, const char *out_addr
 	// Test inject a simple packet to test malvink communication Camera to Ground
 	signal(SIGUSR1, sendtestmsg);
 
-	if (serial_fd > 0 && !enable_simple_uart) { // if UART opened and we need to read it via events
+	if (serial_fd >= 0 && !enable_simple_uart) { // if UART opened and we need to read it via events
 		serial_bev = bufferevent_socket_new(base, serial_fd, 0);
 
 		// Trigger the read callback only whenever there is at least 16 bytes of data in the buffer.
@@ -1355,7 +1361,7 @@ static int handle_data(const char *port_name, int baudrate, const char *out_addr
 
 	// MSP_PollRate
 	if (ParseMSP && msp_tmr == NULL &&
-		serial_fd > 0) { // Only if we are on Cam, on ground no need to poll
+		serial_fd >= 0) { // Only if we are on Cam, on ground no need to poll
 		msp_tmr = event_new(base, -1, EV_PERSIST, poll_msp, &serial_fd);
 		// Set poll interval to 50 milliseconds if pollrate is 20
 		struct timeval interval = {

--- a/msposd.c
+++ b/msposd.c
@@ -1182,7 +1182,7 @@ static void poll_msp(evutil_socket_t sock, short event, void *arg) {
 
 static int handle_data(const char *port_name, int baudrate, const char *out_addr) {
 	struct event *sig_int = NULL, *in_ev = NULL, *temp_tmr = NULL, *msp_tmr = NULL;
-	struct event *sig_term;
+	struct event *sig_term = NULL;
 	int ret = EXIT_SUCCESS;
 
 	// Read from UDP
@@ -1390,13 +1390,15 @@ err:
 
 	if (sig_int)
 		event_free(sig_int);
+	if (sig_term)
+		event_free(sig_term);
+
+	CloseMSP();
 
 	if (base)
 		event_base_free(base);
 
 	libevent_global_shutdown();
-
-	CloseMSP();
 
 	return ret;
 }

--- a/osd/util/Render_gs.c
+++ b/osd/util/Render_gs.c
@@ -516,9 +516,10 @@ void FlushDrawing() {
     if (x11_event == NULL && base != NULL) {
         // Attach X11 display's file descriptor to the existing msposd
         // event_base
-        struct event *x11_event =
+        x11_event =
             event_new(base, ConnectionNumber(display), EV_READ | EV_PERSIST, event_callback, NULL);
-        event_add(x11_event, NULL);
+        if (x11_event)
+            event_add(x11_event, NULL);
 
         XGrabKey(display, XKeysymToKeycode(display, XK_Up), Mod1Mask, RootWindow, True,
             GrabModeAsync,

--- a/osd/util/Render_gs.c
+++ b/osd/util/Render_gs.c
@@ -566,15 +566,54 @@ void FlushDrawing() {
 
 void Close() {
 	// Clean up resources
-	cairo_destroy(cr);
-	cairo_destroy(cr_back);
-	cairo_surface_destroy(image_surface);
-	cairo_surface_destroy(surface);
-	cairo_surface_destroy(surface_back);
+	if (image_surface) {
+		cairo_surface_destroy(image_surface);
+		image_surface = NULL;
+	}
+#if defined(_x86)
+	if (x11_event) {
+		event_del(x11_event);
+		event_free(x11_event);
+		x11_event = NULL;
+	}
+
+	if (!shm_image) {
+		if (cr) {
+			cairo_destroy(cr);
+			cr = NULL;
+		}
+		if (surface) {
+			cairo_surface_destroy(surface);
+			surface = NULL;
+		}
+	} else {
+		cr = NULL;
+		surface = NULL;
+	}
+#else
+	if (cr) {
+		cairo_destroy(cr);
+		cr = NULL;
+	}
+	if (surface) {
+		cairo_surface_destroy(surface);
+		surface = NULL;
+	}
+#endif
+	if (cr_back) {
+		cairo_destroy(cr_back);
+		cr_back = NULL;
+	}
+	if (surface_back) {
+		cairo_surface_destroy(surface_back);
+		surface_back = NULL;
+	}
+
 #if defined(_x86)
 	// Clean up XShm triple-buffer resources
 	if (shm_image) {
-		XShmDetach(display, &shm_seg);
+		if (display)
+			XShmDetach(display, &shm_seg);
 		XDestroyImage(shm_image);
 		shm_image = NULL;
 	}
@@ -605,12 +644,13 @@ void Close() {
 		shm_sysv_id = -1;
 	}
 	
-	XDestroyWindow(display, window);
-	XCloseDisplay(display);
-
-	// Cleanup
-	event_free(x11_event);
-	event_base_free(base);
+	if (display) {
+		if (window)
+			XDestroyWindow(display, window);
+		XCloseDisplay(display);
+		display = NULL;
+		window = 0;
+	}
 #endif
 }
 


### PR DESCRIPTION
Fixes several lifecycle and resource-management issues:
- Prevents repeated X11 event registration and hotkey grabs during rendering.
- Cleans up X11, Cairo, shared-memory, and libevent resources safely on shutdown.
- Ensures renderer cleanup occurs before the shared libevent base is released.
- Treats an absent UART as -1 and skips terminal configuration in UDP mode, preserving the caller’s terminal settings.

Assisted by: OpenAI Codex 5.6